### PR TITLE
Link to alternative in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,6 @@
-This project is no longer maintained.
+This project is no longer maintained. See https://github.com/antechrestos/cf-python-client for an alternative. 
 
 The contents of this repository are still available in the Git source code
 management system. To see the contents of this repository before it reached
 its end of life, please check out the previous commit with 
 "git checkout HEAD^1".
-


### PR DESCRIPTION
As this repo is still one of the first hits in Google, it would be helpful to redirect people to an active alternative.
